### PR TITLE
fix: ensure ThemeProvider wraps App to resolve context error

### DIFF
--- a/repo.md
+++ b/repo.md
@@ -39,3 +39,13 @@ Verified implementation of Onboarding page and Home page links. Validation passe
 
 ---
 
+
+## {anyx b0ff7bb1-492a-464f-860a-df169df17f41} - 2026-02-05 07:59:20
+
+Commit: `a96270edef723ed692deb28ce2b10f4aa8446d54`
+Branch: `feature/b0ff7bb1-492a-464f-860a-df169df17f41`
+
+Fixed 'useTheme must be used within <ThemeProvider>' error by wrapping the App component with ThemeProvider in src/main.tsx. This ensures theme context is available globally to all components, including the Onboarding page.
+
+---
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import './index.css';
 import './lib/console-logger'; // CRITICAL: DO NOT DELETE THIS LINE
 import { ErrorBoundary } from './components/ErrorBoundary'; // Ensure this component exists or use a simple wrapper
 import { BrowserRouter } from 'react-router-dom';
+import { ThemeProvider } from './theme/ThemeProvider';
 
 // Simple ErrorBoundary if not imported (Self-contained for safety)
 class SafeErrorBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean }> {
@@ -33,8 +34,11 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <SafeErrorBoundary>
       <BrowserRouter>
-        <App />
+        <ThemeProvider>
+          <App />
+        </ThemeProvider>
       </BrowserRouter>
     </SafeErrorBoundary>
   </React.StrictMode>,
 );
+


### PR DESCRIPTION
## Description
Fixed the "useTheme must be used within <ThemeProvider>" error encountered on the Onboarding page.

## Changes
- Wrapped the `<App />` component with `<ThemeProvider>` in `src/main.tsx`.
- This ensures that the theme context is available to the entire component tree, resolving the runtime error.

## Verification
- Verified that `src/main.tsx` correctly imports and uses `ThemeProvider`.
- Ran runtime tests to ensure no crashes on startup.
